### PR TITLE
feat: add architecture parameter support for Lambda Layer

### DIFF
--- a/.projen/deps.json
+++ b/.projen/deps.json
@@ -92,6 +92,10 @@
       "type": "build"
     },
     {
+      "name": "ts-node",
+      "type": "build"
+    },
+    {
       "name": "typescript",
       "version": "^4.9",
       "type": "build"

--- a/.projen/tasks.json
+++ b/.projen/tasks.json
@@ -286,13 +286,13 @@
       },
       "steps": [
         {
-          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/mock-fs,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest"
+          "exec": "npx npm-check-updates@16 --upgrade --target=minor --peer --no-deprecated --dep=dev,peer,prod,optional --filter=@types/jest,@types/mock-fs,eslint-import-resolver-typescript,eslint-plugin-import,jest,jsii-diff,jsii-pacmak,projen,ts-jest,ts-node"
         },
         {
           "exec": "yarn install --check-files"
         },
         {
-          "exec": "yarn upgrade @stylistic/eslint-plugin @types/jest @types/mock-fs @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest typescript aws-cdk-lib constructs"
+          "exec": "yarn upgrade @stylistic/eslint-plugin @types/jest @types/mock-fs @types/node @typescript-eslint/eslint-plugin @typescript-eslint/parser commit-and-tag-version eslint-import-resolver-typescript eslint-plugin-import eslint jest jest-junit jsii-diff jsii-docgen jsii-pacmak jsii-rosetta jsii projen ts-jest ts-node typescript aws-cdk-lib constructs"
         },
         {
           "exec": "npx projen"

--- a/.projenrc.js
+++ b/.projenrc.js
@@ -39,6 +39,7 @@ const project = new awscdk.AwsCdkConstructLibrary({
     'typescript@4.6',
     'mock-fs@5.1.2',
     '@types/mock-fs',
+    'ts-node',
   ],
   typescriptVersion: '^4.9',
 });

--- a/API.md
+++ b/API.md
@@ -4,20 +4,19 @@
 
 ### SecretManagerWrapperLayer <a name="SecretManagerWrapperLayer" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer"></a>
 
-An AWS SecretManager Wrapper layer that includes the AWS CLI, jq etc...
-
 #### Initializers <a name="Initializers" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.Initializer"></a>
 
 ```typescript
 import { SecretManagerWrapperLayer } from 'cdk-secret-manager-wrapper-layer'
 
-new SecretManagerWrapperLayer(scope: Construct, id: string)
+new SecretManagerWrapperLayer(scope: Construct, id: string, props?: SecretManagerWrapperLayerProps)
 ```
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.Initializer.parameter.scope">scope</a></code> | <code>constructs.Construct</code> | *No description.* |
 | <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.Initializer.parameter.id">id</a></code> | <code>string</code> | *No description.* |
+| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.Initializer.parameter.props">props</a></code> | <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayerProps">SecretManagerWrapperLayerProps</a></code> | *No description.* |
 
 ---
 
@@ -33,13 +32,17 @@ new SecretManagerWrapperLayer(scope: Construct, id: string)
 
 ---
 
+##### `props`<sup>Optional</sup> <a name="props" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.Initializer.parameter.props"></a>
+
+- *Type:* <a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayerProps">SecretManagerWrapperLayerProps</a>
+
+---
+
 #### Methods <a name="Methods" id="Methods"></a>
 
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.toString">toString</a></code> | Returns a string representation of this construct. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.applyRemovalPolicy">applyRemovalPolicy</a></code> | Apply the given removal policy to this resource. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.addPermission">addPermission</a></code> | Add permission for this layer version to specific entities. |
 
 ---
 
@@ -51,65 +54,11 @@ public toString(): string
 
 Returns a string representation of this construct.
 
-##### `applyRemovalPolicy` <a name="applyRemovalPolicy" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.applyRemovalPolicy"></a>
-
-```typescript
-public applyRemovalPolicy(policy: RemovalPolicy): void
-```
-
-Apply the given removal policy to this resource.
-
-The Removal Policy controls what happens to this resource when it stops
-being managed by CloudFormation, either because you've removed it from the
-CDK application or because you've made a change that requires the resource
-to be replaced.
-
-The resource can be deleted (`RemovalPolicy.DESTROY`), or left in your AWS
-account for data recovery and cleanup later (`RemovalPolicy.RETAIN`).
-
-###### `policy`<sup>Required</sup> <a name="policy" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.applyRemovalPolicy.parameter.policy"></a>
-
-- *Type:* aws-cdk-lib.RemovalPolicy
-
----
-
-##### `addPermission` <a name="addPermission" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.addPermission"></a>
-
-```typescript
-public addPermission(id: string, permission: LayerVersionPermission): void
-```
-
-Add permission for this layer version to specific entities.
-
-Usage within
-the same account where the layer is defined is always allowed and does not
-require calling this method. Note that the principal that creates the
-Lambda function using the layer (for example, a CloudFormation changeset
-execution role) also needs to have the ``lambda:GetLayerVersion``
-permission on the layer version.
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.addPermission.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `permission`<sup>Required</sup> <a name="permission" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.addPermission.parameter.permission"></a>
-
-- *Type:* aws-cdk-lib.aws_lambda.LayerVersionPermission
-
----
-
 #### Static Functions <a name="Static Functions" id="Static Functions"></a>
 
 | **Name** | **Description** |
 | --- | --- |
 | <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isConstruct">isConstruct</a></code> | Checks if `x` is a construct. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isOwnedResource">isOwnedResource</a></code> | Returns true if the construct was created by CDK, and false otherwise. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isResource">isResource</a></code> | Check whether the given construct is a Resource. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionArn">fromLayerVersionArn</a></code> | Imports a layer version by ARN. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionAttributes">fromLayerVersionAttributes</a></code> | Imports a Layer that has been defined externally. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.getOrCreate">getOrCreate</a></code> | *No description.* |
 
 ---
 
@@ -131,125 +80,12 @@ Any object.
 
 ---
 
-##### `isOwnedResource` <a name="isOwnedResource" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isOwnedResource"></a>
-
-```typescript
-import { SecretManagerWrapperLayer } from 'cdk-secret-manager-wrapper-layer'
-
-SecretManagerWrapperLayer.isOwnedResource(construct: IConstruct)
-```
-
-Returns true if the construct was created by CDK, and false otherwise.
-
-###### `construct`<sup>Required</sup> <a name="construct" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isOwnedResource.parameter.construct"></a>
-
-- *Type:* constructs.IConstruct
-
----
-
-##### `isResource` <a name="isResource" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isResource"></a>
-
-```typescript
-import { SecretManagerWrapperLayer } from 'cdk-secret-manager-wrapper-layer'
-
-SecretManagerWrapperLayer.isResource(construct: IConstruct)
-```
-
-Check whether the given construct is a Resource.
-
-###### `construct`<sup>Required</sup> <a name="construct" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.isResource.parameter.construct"></a>
-
-- *Type:* constructs.IConstruct
-
----
-
-##### `fromLayerVersionArn` <a name="fromLayerVersionArn" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionArn"></a>
-
-```typescript
-import { SecretManagerWrapperLayer } from 'cdk-secret-manager-wrapper-layer'
-
-SecretManagerWrapperLayer.fromLayerVersionArn(scope: Construct, id: string, layerVersionArn: string)
-```
-
-Imports a layer version by ARN.
-
-Assumes it is compatible with all Lambda runtimes.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionArn.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionArn.parameter.id"></a>
-
-- *Type:* string
-
----
-
-###### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionArn.parameter.layerVersionArn"></a>
-
-- *Type:* string
-
----
-
-##### `fromLayerVersionAttributes` <a name="fromLayerVersionAttributes" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionAttributes"></a>
-
-```typescript
-import { SecretManagerWrapperLayer } from 'cdk-secret-manager-wrapper-layer'
-
-SecretManagerWrapperLayer.fromLayerVersionAttributes(scope: Construct, id: string, attrs: LayerVersionAttributes)
-```
-
-Imports a Layer that has been defined externally.
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionAttributes.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
-the parent Construct that will use the imported layer.
-
----
-
-###### `id`<sup>Required</sup> <a name="id" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionAttributes.parameter.id"></a>
-
-- *Type:* string
-
-the id of the imported layer in the construct tree.
-
----
-
-###### `attrs`<sup>Required</sup> <a name="attrs" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.fromLayerVersionAttributes.parameter.attrs"></a>
-
-- *Type:* aws-cdk-lib.aws_lambda.LayerVersionAttributes
-
-the properties of the imported layer.
-
----
-
-##### `getOrCreate` <a name="getOrCreate" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.getOrCreate"></a>
-
-```typescript
-import { SecretManagerWrapperLayer } from 'cdk-secret-manager-wrapper-layer'
-
-SecretManagerWrapperLayer.getOrCreate(scope: Construct)
-```
-
-###### `scope`<sup>Required</sup> <a name="scope" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.getOrCreate.parameter.scope"></a>
-
-- *Type:* constructs.Construct
-
----
-
 #### Properties <a name="Properties" id="Properties"></a>
 
 | **Name** | **Type** | **Description** |
 | --- | --- | --- |
 | <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.node">node</a></code> | <code>constructs.Node</code> | The tree node. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.env">env</a></code> | <code>aws-cdk-lib.ResourceEnvironment</code> | The environment this resource belongs to. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.stack">stack</a></code> | <code>aws-cdk-lib.Stack</code> | The stack in which this resource is defined. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.layerVersionArn">layerVersionArn</a></code> | <code>string</code> | The ARN of the Lambda Layer version that this Layer defines. |
-| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.compatibleRuntimes">compatibleRuntimes</a></code> | <code>aws-cdk-lib.aws_lambda.Runtime[]</code> | The runtimes compatible with this Layer. |
+| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.layerVersion">layerVersion</a></code> | <code>aws-cdk-lib.aws_lambda.ILayerVersion</code> | *No description.* |
 
 ---
 
@@ -265,62 +101,48 @@ The tree node.
 
 ---
 
-##### `env`<sup>Required</sup> <a name="env" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.env"></a>
+##### `layerVersion`<sup>Required</sup> <a name="layerVersion" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.layerVersion"></a>
 
 ```typescript
-public readonly env: ResourceEnvironment;
+public readonly layerVersion: ILayerVersion;
 ```
 
-- *Type:* aws-cdk-lib.ResourceEnvironment
-
-The environment this resource belongs to.
-
-For resources that are created and managed by the CDK
-(generally, those created by creating new class instances like Role, Bucket, etc.),
-this is always the same as the environment of the stack they belong to;
-however, for imported resources
-(those obtained from static methods like fromRoleArn, fromBucketName, etc.),
-that might be different than the stack they were imported into.
-
----
-
-##### `stack`<sup>Required</sup> <a name="stack" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.stack"></a>
-
-```typescript
-public readonly stack: Stack;
-```
-
-- *Type:* aws-cdk-lib.Stack
-
-The stack in which this resource is defined.
-
----
-
-##### `layerVersionArn`<sup>Required</sup> <a name="layerVersionArn" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.layerVersionArn"></a>
-
-```typescript
-public readonly layerVersionArn: string;
-```
-
-- *Type:* string
-
-The ARN of the Lambda Layer version that this Layer defines.
-
----
-
-##### `compatibleRuntimes`<sup>Optional</sup> <a name="compatibleRuntimes" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayer.property.compatibleRuntimes"></a>
-
-```typescript
-public readonly compatibleRuntimes: Runtime[];
-```
-
-- *Type:* aws-cdk-lib.aws_lambda.Runtime[]
-
-The runtimes compatible with this Layer.
+- *Type:* aws-cdk-lib.aws_lambda.ILayerVersion
 
 ---
 
 
+## Structs <a name="Structs" id="Structs"></a>
+
+### SecretManagerWrapperLayerProps <a name="SecretManagerWrapperLayerProps" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayerProps"></a>
+
+#### Initializer <a name="Initializer" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayerProps.Initializer"></a>
+
+```typescript
+import { SecretManagerWrapperLayerProps } from 'cdk-secret-manager-wrapper-layer'
+
+const secretManagerWrapperLayerProps: SecretManagerWrapperLayerProps = { ... }
+```
+
+#### Properties <a name="Properties" id="Properties"></a>
+
+| **Name** | **Type** | **Description** |
+| --- | --- | --- |
+| <code><a href="#cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayerProps.property.lambdaArchitecture">lambdaArchitecture</a></code> | <code>aws-cdk-lib.aws_lambda.Architecture</code> | The architecture for the Lambda function that will use this layer. |
+
+---
+
+##### `lambdaArchitecture`<sup>Optional</sup> <a name="lambdaArchitecture" id="cdk-secret-manager-wrapper-layer.SecretManagerWrapperLayerProps.property.lambdaArchitecture"></a>
+
+```typescript
+public readonly lambdaArchitecture: Architecture;
+```
+
+- *Type:* aws-cdk-lib.aws_lambda.Architecture
+
+The architecture for the Lambda function that will use this layer.
+
+---
 
 
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,7 @@
     "mock-fs": "5.1.2",
     "projen": "^0.91.13",
     "ts-jest": "^27",
+    "ts-node": "^10.9.2",
     "typescript": "^4.9"
   },
   "peerDependencies": {

--- a/src/layer.ts
+++ b/src/layer.ts
@@ -1,31 +1,42 @@
 import * as path from 'path';
-import { DockerImage, RemovalPolicy, Stack } from 'aws-cdk-lib';
+import { DockerImage, RemovalPolicy, Annotations } from 'aws-cdk-lib';
 import * as lambda from 'aws-cdk-lib/aws-lambda';
 import { Construct } from 'constructs';
 
-
-/**
- * An AWS SecretManager Wrapper layer that includes the AWS CLI, jq etc...
- */
-export class SecretManagerWrapperLayer extends lambda.LayerVersion {
-  public static getOrCreate(scope: Construct): SecretManagerWrapperLayer {
-    const stack = Stack.of(scope);
-    const id = 'DenoLayer';
-    const existing = stack.node.tryFindChild(id);
-    return (existing as SecretManagerWrapperLayer) || new SecretManagerWrapperLayer(stack, id);
-  }
-  constructor(scope: Construct, id: string) {
-
-    const image = DockerImage.fromBuild(path.join(__dirname, '../layer'));
+export interface SecretManagerWrapperLayerProps {
+  /**
+   * The architecture for the Lambda function that will use this layer
+   */
+  readonly lambdaArchitecture?: lambda.Architecture;
+}
+export class SecretManagerWrapperLayer extends Construct {
+  // public static getOrCreate(scope: Construct): SecretManagerWrapperLayer {
+  //   const stack = Stack.of(scope);
+  //   const id = 'SecretManagerWrapperLayer';
+  //   const existing = stack.node.tryFindChild(id);
+  //   return (existing as SecretManagerWrapperLayer) || new SecretManagerWrapperLayer(stack, id, );
+  // }
+  public readonly layerVersion: lambda.ILayerVersion;
+  constructor(scope: Construct, id: string, props?: SecretManagerWrapperLayerProps) {
+    super(scope, id);
+    const image = DockerImage.fromBuild(path.join(__dirname, '../layer'), {
+      platform: props?.lambdaArchitecture! == lambda.Architecture.ARM_64 ? 'linux/arm64' : 'linux/amd64',
+      file: 'Dockerfile',
+    });
     image.cp('/layer.zip', path.join(__dirname));
 
-    const props: lambda.LayerVersionProps = {
+    const layerVersionProps: lambda.LayerVersionProps = {
       removalPolicy: RemovalPolicy.DESTROY,
       code: lambda.Code.fromAsset(path.join(__dirname, 'layer.zip')),
       description: 'this layer has wrapper script help you setting secret manager json string into lambda runtime',
     };
 
-    super(scope, id, props);
+    if (!props?.lambdaArchitecture) {
+      Annotations.of(this).addWarning(
+        'The Lambda Function that uses this layer will need to have a runtime that supports X86_64 linux/amd64.',
+      );
+    }
 
+    this.layerVersion = new lambda.LayerVersion(this, 'SecretManagerWrapperLayer', layerVersionProps);
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -300,6 +300,13 @@
   resolved "https://registry.yarnpkg.com/@bcoe/v8-coverage/-/v8-coverage-0.2.3.tgz#75a2e8b51cb758a7553d6804a5932d7aace75c39"
   integrity sha512-0hYQ8SB4Db5zvZB4axdMHGwEaQjkZzFjQiN9LVYvIFB2nSUHW9tYpxWriPrWDASIxiaXax83REcLxuSdnGPZtw==
 
+"@cspotcode/source-map-support@^0.8.0":
+  version "0.8.1"
+  resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
+  integrity sha512-IchNf6dN4tHoMFIn/7OE8LWZ19Y6q/67Bmf6vnGREv8RSbBVb9LPJxEcnwrcwX6ixSvaiGoomAUvu4YSxXrVgw==
+  dependencies:
+    "@jridgewell/trace-mapping" "0.3.9"
+
 "@csstools/color-helpers@^5.0.2":
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/@csstools/color-helpers/-/color-helpers-5.0.2.tgz#82592c9a7c2b83c293d9161894e2a6471feb97b8"
@@ -621,7 +628,7 @@
     "@jridgewell/sourcemap-codec" "^1.4.10"
     "@jridgewell/trace-mapping" "^0.3.24"
 
-"@jridgewell/resolve-uri@^3.1.0":
+"@jridgewell/resolve-uri@^3.0.3", "@jridgewell/resolve-uri@^3.1.0":
   version "3.1.2"
   resolved "https://registry.yarnpkg.com/@jridgewell/resolve-uri/-/resolve-uri-3.1.2.tgz#7a0ee601f60f99a20c7c7c5ff0c80388c1189bd6"
   integrity sha512-bRISgCIjP20/tbWSPWMEi54QVPRZExkuD9lJL+UIxUKtwVJA8wW1Trb1jMs1RFXo1CBTNZ/5hpC9QvmKWdopKw==
@@ -635,6 +642,14 @@
   version "1.5.0"
   resolved "https://registry.yarnpkg.com/@jridgewell/sourcemap-codec/-/sourcemap-codec-1.5.0.tgz#3188bcb273a414b0d215fd22a58540b989b9409a"
   integrity sha512-gv3ZRaISU3fjPAgNsriBRqGWQL6quFx04YMPW/zD8XMLsU32mhCCbfbO6KZFLjvYpCZ8zyDEgqsgf+PwPaM7GQ==
+
+"@jridgewell/trace-mapping@0.3.9":
+  version "0.3.9"
+  resolved "https://registry.yarnpkg.com/@jridgewell/trace-mapping/-/trace-mapping-0.3.9.tgz#6534fd5933a53ba7cbf3a17615e273a0d1273ff9"
+  integrity sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==
+  dependencies:
+    "@jridgewell/resolve-uri" "^3.0.3"
+    "@jridgewell/sourcemap-codec" "^1.4.10"
 
 "@jridgewell/trace-mapping@^0.3.24", "@jridgewell/trace-mapping@^0.3.25":
   version "0.3.25"
@@ -756,6 +771,26 @@
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/@tootallnate/once/-/once-1.1.2.tgz#ccb91445360179a04e7fe6aff78c00ffc1eeaf82"
   integrity sha512-RbzJvlNzmRq5c3O09UipeuXno4tA1FE6ikOjxZK0tuxVv3412l64l5t1W5pj4+rJq9vpkm/kwiR07aZXnsKPxw==
+
+"@tsconfig/node10@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node10/-/node10-1.0.11.tgz#6ee46400685f130e278128c7b38b7e031ff5b2f2"
+  integrity sha512-DcRjDCujK/kCk/cUe8Xz8ZSpm8mS3mNNpta+jGCA6USEDfktlNvm1+IuZ9eTcDbNk41BHwpHHeW+N1lKCz4zOw==
+
+"@tsconfig/node12@^1.0.7":
+  version "1.0.11"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node12/-/node12-1.0.11.tgz#ee3def1f27d9ed66dac6e46a295cffb0152e058d"
+  integrity sha512-cqefuRsh12pWyGsIoBKJA9luFu3mRxCA+ORZvA4ktLSzIuCUtWVxGIuXigEwO5/ywWFMZ2QEGKWvkZG1zDMTag==
+
+"@tsconfig/node14@^1.0.0":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node14/-/node14-1.0.3.tgz#e4386316284f00b98435bf40f72f75a09dabf6c1"
+  integrity sha512-ysT8mhdixWK6Hw3i1V2AeRqZ5WfXg1G43mqoYlM2nc6388Fq5jcXyr5mRsqViLx/GJYdoL0bfXD8nmF+Zn/Iow==
+
+"@tsconfig/node16@^1.0.2":
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/@tsconfig/node16/-/node16-1.0.4.tgz#0b92dcc0cc1c81f6f306a381f28e31b1a56536e9"
+  integrity sha512-vxhUy4J8lyeyinH7Azl1pdd43GJhZH/tP2weN8TntQblOY+A0XbT8DJk1/oCPuOOyg/Ja757rG0CgHcWC8OfMA==
 
 "@types/babel__core@^7.0.0", "@types/babel__core@^7.1.14":
   version "7.20.5"
@@ -1009,12 +1044,19 @@ acorn-walk@^7.1.1:
   resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-7.2.0.tgz#0de889a601203909b0fbe07b8938dc21d2e967bc"
   integrity sha512-OPdCF6GsMIP+Az+aWfAAOEt2/+iVDKE7oy6lJ098aoe59oAmK76qV6Gw60SbZ8jHuG2wH058GF4pLFbYamYrVA==
 
+acorn-walk@^8.1.1:
+  version "8.3.4"
+  resolved "https://registry.yarnpkg.com/acorn-walk/-/acorn-walk-8.3.4.tgz#794dd169c3977edf4ba4ea47583587c5866236b7"
+  integrity sha512-ueEepnujpqee2o5aIYnvHU6C0A42MNdsIDeqy5BydrkuC5R1ZuUFnm27EeFJGoEHJQgn3uleRvmTXaJgfXbt4g==
+  dependencies:
+    acorn "^8.11.0"
+
 acorn@^7.1.1:
   version "7.4.1"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-7.4.1.tgz#feaed255973d2e77555b83dbc08851a6c63520fa"
   integrity sha512-nQyp0o1/mNdbTO1PO6kHkwSrmgZ0MT/jCCpNiwbUjGoRN4dlBhqJtoQuCnEOKzgTVwg0ZWiCoQy6SxMebQVh8A==
 
-acorn@^8.14.0, acorn@^8.2.4:
+acorn@^8.11.0, acorn@^8.14.0, acorn@^8.2.4, acorn@^8.4.1:
   version "8.14.0"
   resolved "https://registry.yarnpkg.com/acorn/-/acorn-8.14.0.tgz#063e2c70cac5fb4f6467f0b11152e04c682795b0"
   integrity sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==
@@ -1094,6 +1136,11 @@ anymatch@^3.0.3:
   dependencies:
     normalize-path "^3.0.0"
     picomatch "^2.0.4"
+
+arg@^4.1.0:
+  version "4.1.3"
+  resolved "https://registry.yarnpkg.com/arg/-/arg-4.1.3.tgz#269fc7ad5b8e42cb63c896d5666017261c144089"
+  integrity sha512-58S9QDqG0Xx27YwPSt9fJxivjYl432YCwfDMfZ+71RAqUrZef7LrKQZ3LHLOwCS4FLNBplP533Zx895SeOCHvA==
 
 argparse@^1.0.7:
   version "1.0.10"
@@ -1748,6 +1795,11 @@ core-util-is@^1.0.3, core-util-is@~1.0.0:
   resolved "https://registry.yarnpkg.com/core-util-is/-/core-util-is-1.0.3.tgz#a6042d3634c2b27e9328f837b965fac83808db85"
   integrity sha512-ZQBvi1DcpJ4GDqanjucZ2Hj3wEO5pZDS89BWbkcrvdxksJorwUDDZamX9ldFkp9aw2lmBDLgkObEA4DWNJ9FYQ==
 
+create-require@^1.1.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/create-require/-/create-require-1.1.1.tgz#c1d7e8f1e5f6cfc9ff65f9cd352d37348756c333"
+  integrity sha512-dcKFX3jn0MpIaXjisoRvexIJVEKzaq7z2rZKxf+MSr9TkdmHmsU4m2lcLojrj/FHl8mk5VxMmYA+ftRkP/3oKQ==
+
 cross-spawn@^7.0.3, cross-spawn@^7.0.6:
   version "7.0.6"
   resolved "https://registry.yarnpkg.com/cross-spawn/-/cross-spawn-7.0.6.tgz#8a58fe78f00dcd70c370451759dfbfaf03e8ee9f"
@@ -1940,6 +1992,11 @@ diff-sequences@^27.5.1:
   version "27.5.1"
   resolved "https://registry.yarnpkg.com/diff-sequences/-/diff-sequences-27.5.1.tgz#eaecc0d327fd68c8d9672a1e64ab8dccb2ef5327"
   integrity sha512-k1gCAXAsNgLwEL+Y8Wvl+M6oEFj5bgazfZULpS5CneoPPXRaCCW7dm+q21Ky2VEE5X+VeRDBVg1Pcvvsr4TtNQ==
+
+diff@^4.0.1:
+  version "4.0.2"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-4.0.2.tgz#60f3aecb89d5fae520c11aa19efc2bb982aade7d"
+  integrity sha512-58lmxKSA4BNyLz+HHMUzlOEpg09FV+ev6ZMe3vJihgdxzgcwZ8VoEEPmALCZG9LmqfVoNMMKpttIYTVG6uDY7A==
 
 doctrine@^2.1.0:
   version "2.1.0"
@@ -4029,7 +4086,7 @@ make-dir@^4.0.0:
   dependencies:
     semver "^7.5.3"
 
-make-error@1.x:
+make-error@1.x, make-error@^1.1.1:
   version "1.3.6"
   resolved "https://registry.yarnpkg.com/make-error/-/make-error-1.3.6.tgz#2eb2e37ea9b67c4891f684a1394799af484cf7a2"
   integrity sha512-s8UhlNe7vPKomQhC1qFelMokr/Sc3AgNbso3n74mVPA5LTZwkB9NlXf4XPamLxJE8h0gh73rM94xvwRT2CVInw==
@@ -5351,6 +5408,25 @@ ts-jest@^27:
     semver "7.x"
     yargs-parser "20.x"
 
+ts-node@^10.9.2:
+  version "10.9.2"
+  resolved "https://registry.yarnpkg.com/ts-node/-/ts-node-10.9.2.tgz#70f021c9e185bccdca820e26dc413805c101c71f"
+  integrity sha512-f0FFpIdcHgn8zcPSbf1dRevwt047YMnaiJM3u2w2RewrB+fob/zePZcrOyQoLMMO7aBIddLcQIEK5dYjkLnGrQ==
+  dependencies:
+    "@cspotcode/source-map-support" "^0.8.0"
+    "@tsconfig/node10" "^1.0.7"
+    "@tsconfig/node12" "^1.0.7"
+    "@tsconfig/node14" "^1.0.0"
+    "@tsconfig/node16" "^1.0.2"
+    acorn "^8.4.1"
+    acorn-walk "^8.1.1"
+    arg "^4.1.0"
+    create-require "^1.1.0"
+    diff "^4.0.1"
+    make-error "^1.1.1"
+    v8-compile-cache-lib "^3.0.1"
+    yn "3.1.1"
+
 tsconfig-paths@^3.15.0:
   version "3.15.0"
   resolved "https://registry.yarnpkg.com/tsconfig-paths/-/tsconfig-paths-3.15.0.tgz#5299ec605e55b1abb23ec939ef15edaf483070d4"
@@ -5532,6 +5608,11 @@ uuid@^8.3.2:
   version "8.3.2"
   resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
   integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
+
+v8-compile-cache-lib@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.yarnpkg.com/v8-compile-cache-lib/-/v8-compile-cache-lib-3.0.1.tgz#6336e8d71965cb3d35a1bbb7868445a7c05264bf"
+  integrity sha512-wa7YjyUGfNZngI/vtK0UHAN+lgDCxBPCylVXGp0zu59Fz5aiGtNXaq3DhIov063MorB+VfufLh3JlF2KdTK3xg==
 
 v8-to-istanbul@^8.1.0:
   version "8.1.1"
@@ -5842,6 +5923,11 @@ yargs@^17.7.2:
     string-width "^4.2.3"
     y18n "^5.0.5"
     yargs-parser "^21.1.1"
+
+yn@3.1.1:
+  version "3.1.1"
+  resolved "https://registry.yarnpkg.com/yn/-/yn-3.1.1.tgz#1e87401a09d767c1d5eab26a6e4c185182d2eb50"
+  integrity sha512-Ux4ygGWsu2c7isFWe8Yu1YluJmqVhxqK2cLXNQA5AcC3QfbGNpM7fu0Y8b/z16pXLnFxZYvWhd3fhBY9DLmC6Q==
 
 yocto-queue@^0.1.0:
   version "0.1.0"


### PR DESCRIPTION
# Add Architecture Parameter Support for Lambda Layer

## Changes
- Added architecture parameter support for Lambda Layer
- Updated Python runtime example from 3.9 to 3.13
- Fixed handler name in example code
- Improved layer initialization and referencing patterns
- Enhanced compatibility with AWS Lambda ARM64 architecture
- Added version update note in README.md
## Testing
- Tested with both x86_64 and ARM64 architecture settings
- Verified CDK synthesis works correctly with the new parameters
- Updated test files to support the architecture parameter


## Release Plan
Planned for release in v2.1.0
